### PR TITLE
Change API for accessing the surveys

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,22 +36,29 @@ Getting started
 API
 ---
 ```python
-from galcheat import survey_info
+# A list of available surveys
+from galcheat import available_surveys
+# Getter methods to retrieve a Survey of a Filter dataclass
+from galcheat import get_survey, get_filters
+Rubin = get_survey("Rubin")
+u_band = get_filter("u", Rubin)
 
-# Available surveys
-print(list(survey_info.keys()))
+# Get a dictionary of all available filters
+Rubin.get_filters()
 
-# Rubin U band PSF FWHM
-Rubin = survey_info["Rubin"]
-fwhm = Rubin.filters.u.psf_fwhm  # Quantity object with units
-print(fwhm)
+# Both Survey and Filter classes have physical attributes
+Rubin.mirror_diameter
+u_band.exposure_time
+# Filters are also attributes of a Survey
+Rubin.filters.u.exposure_time  # same as above
 
-# Retrieve the value in the original units
-print(fwhm.value)
-
-# Or convert to other units
+# These attributes are Astropy Quantity objects with units
+fwhm = u_band.psf_fwhm
+# The value in the original units is obtained as
+fwhm.value
+# or it can be converted to other units
 import astropy.units as u
-print(fwhm.to_value(u.arcmin))
+fwhm.to_value(u.arcmin)
 ```
 
 Contributing

--- a/galcheat/__init__.py
+++ b/galcheat/__init__.py
@@ -13,12 +13,11 @@ The data can be viewed in a terminal with
 
     python -m galcheat
 
-To access the quantities, use the main
-dictionary called `survey_info` containing
-`Survey` objects
+To access the quantities, retrieve the
+`Survey` objects with `get_survey`.
 
-    >>> from galcheat import survey_info
-    >>> Rubin = survey_info['Rubin']
+    >>> from galcheat import get_survey
+    >>> Rubin = get_survey('Rubin')
     >>> Rubin.mirror_diameter
     <Quantity 8.36 m>
 
@@ -27,10 +26,10 @@ accessible from the `Survey`
 
     >>> u_filter = Rubin.filters.u
 
-or as an ordered list
+or as a dictionary
 
     >>> filters = Rubin.get_filters()
-    >>> u_filter = filters[0]
+    >>> u_filter = filters['u']
 
 And parameter values can be converted to any
 physical units using the `astropy.units` scheme
@@ -40,7 +39,7 @@ physical units using the `astropy.units` scheme
     >>> u_filter.value
     0.859
 
-    >>> from astropy import units as u
+    >>> import astropy.units as u
     >>> u_filter.psf_fwhm.to(u.arcmin).value
 or
     >>> u_filter.psf_fwhm.to_value(u.arcmin)
@@ -57,7 +56,55 @@ from pathlib import Path
 from galcheat.survey import Survey
 
 _BASEDIR = Path(__file__).parent.resolve()
-
-survey_info = {
+_survey_info = {
     path.stem: Survey.from_yaml(path) for path in _BASEDIR.glob("data/*.yaml")
 }
+
+available_surveys = list(_survey_info.keys())
+
+
+def get_survey(survey_name: str):
+    """Get the dataclass corresponding to the survey
+
+    Raises
+    ------
+    ValueError: when the input survey is not (currently) available
+
+    """
+    if survey_name not in available_surveys:
+        raise ValueError(
+            "Please check the survey name. "
+            f"The available surveys are {available_surveys}"
+        )
+
+    return _survey_info[survey_name]
+
+
+def get_filter(filter_name: str, survey: Survey):
+    """
+    Parameters
+    ----------
+    filter_name: str
+        Name of a filter
+
+
+    Returns
+    -------
+    a filter dataclass
+
+    Raises
+    ------
+    ValueError: when the input filter is not available
+
+    """
+    filter_dict = survey.get_filters()
+    available_filters = list(filter_dict.keys())
+
+    if filter_name not in available_filters:
+        raise ValueError(
+            "Please check the filter name. "
+            f"The available filters for {survey.name} "
+            f"are {available_filters}"
+        )
+
+    return filter_dict[filter_name]

--- a/galcheat/__main__.py
+++ b/galcheat/__main__.py
@@ -1,13 +1,16 @@
-from galcheat import survey_info
+from galcheat import available_surveys, get_survey
 
 
 def main():
-    for survey, info in survey_info.items():
-        print(survey, ":")
-        print("  ", info)
+    for survey_name in available_surveys:
+        survey = get_survey(survey_name)
+        print(survey_name, ":")
+        print("  ", survey)
+
+        survey_filters = survey.get_filters()
         print("   Filters :")
-        for filtinfo in info.get_filters():
-            print("     ", filtinfo)
+        for info in survey_filters.values():
+            print("     ", info)
         print()
 
 

--- a/galcheat/survey.py
+++ b/galcheat/survey.py
@@ -89,5 +89,5 @@ class Survey:
         return FList(**filter_data)
 
     def get_filters(self):
-        """Getter method to retrieve the filters as a list"""
-        return list(self.filters.__dict__.values())
+        """Getter method to retrieve the filters as a dictionary"""
+        return self.filters.__dict__


### PR DESCRIPTION
Instead of the `survey_info` dictionary, we now have a list 
of the available surveys and a getter method to retrieve them.

The getter method will provide a useful error message when the wrong survey name is specified. The same goes for the survey filters.