### PR TITLE
Settle on common set of parameters

### DIFF
--- a/galcheat/data/CFHT.yaml
+++ b/galcheat/data/CFHT.yaml
@@ -5,7 +5,6 @@ name: "CFHT"
 pixel_scale: 0.187
 effective_area: 8.022
 mirror_diameter: 3.592
-airmass: 1.2
 zeropoint_airmass: 1.0
 filters:
   r:

--- a/galcheat/data/CFHT.yaml
+++ b/galcheat/data/CFHT.yaml
@@ -13,12 +13,10 @@ filters:
     sky_brightness: 20.8
     exp_time: 2000
     zeropoint: 26.74
-    extinction: 0.10
     psf_fwhm: 0.71
   i:
     name: "i"
     sky_brightness: 20.3
     exp_time: 4300
     zeropoint: 26.22
-    extinction: 0.07
     psf_fwhm: 0.64

--- a/galcheat/data/DES.yaml
+++ b/galcheat/data/DES.yaml
@@ -6,7 +6,6 @@ sname: DES
 pixel_scale: 0.263
 effective_area: 10.014
 mirror_diameter: 3.934
-airmass: 1.0
 zeropoint_airmass: 1.3
 filters:
   g:

--- a/galcheat/data/DES.yaml
+++ b/galcheat/data/DES.yaml
@@ -2,8 +2,7 @@
 # http://www.ctio.noao.edu/noao/content/DECam-What
 # sky brightness: http://www.ctio.noao.edu/noao/node/1218
 # fwhm: https://arxiv.org/abs/1407.3801 table 2
-# extinction: https://arxiv.org/abs/1701.00502 table 4
-name: DES
+sname: DES
 pixel_scale: 0.263
 effective_area: 10.014
 mirror_diameter: 3.934
@@ -15,26 +14,22 @@ filters:
     sky_brightness: 22.3
     exp_time: 800
     zeropoint: 26.72
-    extinction: 0.17
     psf_fwhm: 1.24
   r:
     name: "r"
     sky_brightness: 21.4
     exp_time: 800
     zeropoint: 26.99
-    extinction: 0.09
     psf_fwhm: 1.03
   i:
     name: "i"
     sky_brightness: 20.5
     exp_time: 1000
     zeropoint: 26.86
-    extinction: 0.05
     psf_fwhm: 0.96
   z:
     name: "z"
     sky_brightness: 18.7
     exp_time: 800
     zeropoint: 26.58
-    extinction: 0.06
     psf_fwhm: 1.12

--- a/galcheat/data/DES.yaml
+++ b/galcheat/data/DES.yaml
@@ -2,7 +2,7 @@
 # http://www.ctio.noao.edu/noao/content/DECam-What
 # sky brightness: http://www.ctio.noao.edu/noao/node/1218
 # fwhm: https://arxiv.org/abs/1407.3801 table 2
-sname: DES
+name: DES
 pixel_scale: 0.263
 effective_area: 10.014
 mirror_diameter: 3.934

--- a/galcheat/data/Euclid_VIS.yaml
+++ b/galcheat/data/Euclid_VIS.yaml
@@ -13,6 +13,5 @@ filters:
     sky_brightness: 22.3203
     exp_time: 565
     zeropoint: 25.91
-    extinction: 0.0
     psf_fwhm: 0.17
     central_wavelength: 713.50

--- a/galcheat/data/HSC.yaml
+++ b/galcheat/data/HSC.yaml
@@ -12,33 +12,28 @@ filters:
     sky_brightness: 21.4
     exp_time: 600
     zeropoint: 28.90
-    extinction: 0.13
     psf_fwhm: 0.77
   r:
     name: "r"
     sky_brightness: 20.6
     exp_time: 600
     zeropoint: 28.86
-    extinction: 0.11
     psf_fwhm: 0.76
   i:
     name: "i"
     sky_brightness: 19.7
     exp_time: 1200
     zeropoint: 28.61
-    extinction: 0.07
     psf_fwhm: 0.58
   z:
     name: "z"
     sky_brightness: 18.3
     exp_time: 1200
     zeropoint: 27.68
-    extinction: 0.05
     psf_fwhm: 0.68
   y:
     name: "y"
     sky_brightness: 17.9
     exp_time: 1200
     zeropoint: 27.33
-    extinction: 0.05
     psf_fwhm: 0.68

--- a/galcheat/data/HSC.yaml
+++ b/galcheat/data/HSC.yaml
@@ -4,7 +4,6 @@ name: HSC
 pixel_scale: 0.167
 effective_area: 52.81
 mirror_diameter: 8.2
-airmass: 1.0
 zeropoint_airmass: 1.2
 filters:
   g:

--- a/galcheat/data/HST.yaml
+++ b/galcheat/data/HST.yaml
@@ -7,7 +7,6 @@ name: "HST_COSMOS"
 pixel_scale: 0.03
 effective_area: 1.0 # TODO: placeholder
 mirror_diameter: 2.4
-airmass: 0.0
 zeropoint_airmass: 0.0
 filters:
   f814w:

--- a/galcheat/data/HST.yaml
+++ b/galcheat/data/HST.yaml
@@ -15,5 +15,4 @@ filters:
     sky_brightness: 22
     exp_time: 2028
     zeropoint: 25.94
-    extinction: 0
     psf_fwhm: 0.074

--- a/galcheat/data/Rubin.yaml
+++ b/galcheat/data/Rubin.yaml
@@ -3,7 +3,6 @@ name: "Rubin"
 pixel_scale: 0.2
 effective_area: 32.4
 mirror_diameter: 8.36
-airmass: 1.2
 zeropoint_airmass: 1.2
 filters:
   u:

--- a/galcheat/data/Rubin.yaml
+++ b/galcheat/data/Rubin.yaml
@@ -11,7 +11,6 @@ filters:
     sky_brightness: 22.9
     exp_time: 1680
     zeropoint: 26.40
-    extinction: 0.451
     psf_fwhm: 0.859
     central_wavelength: 359.213
   g:
@@ -19,7 +18,6 @@ filters:
     sky_brightness: 22.3
     exp_time: 2400
     zeropoint: 28.26
-    extinction: 0.163
     psf_fwhm: 0.814
     central_wavelength: 478.998
   r:
@@ -27,7 +25,6 @@ filters:
     sky_brightness: 21.2
     exp_time: 5520
     zeropoint: 28.10
-    extinction: 0.10
     psf_fwhm: 0.781
     central_wavelength: 619.952
   i:
@@ -35,7 +32,6 @@ filters:
     sky_brightness: 20.5
     exp_time: 5520
     zeropoint: 27.78
-    extinction: 0.07
     psf_fwhm: 0.748
     central_wavelength: 752.851
   z:
@@ -43,7 +39,6 @@ filters:
     sky_brightness: 19.6
     exp_time: 4800
     zeropoint: 27.39
-    extinction: 0.043
     psf_fwhm: 0.725
     central_wavelength: 868.983
   y:
@@ -51,6 +46,5 @@ filters:
     sky_brightness: 18.6
     exp_time: 4800
     zeropoint: 26.56
-    extinction: 0.138
     psf_fwhm: 0.703
     central_wavelength: 967.405

--- a/galcheat/filter.py
+++ b/galcheat/filter.py
@@ -10,9 +10,9 @@ class Filter:
     name: str
     psf_fwhm: Quantity
     zeropoint: Quantity
-    extinction: Quantity
     sky_brightness: Quantity
     exposure_time: Quantity
+    extinction: Optional[Quantity] = None
     central_wavelength: Optional[Quantity] = None
 
     @classmethod
@@ -35,9 +35,10 @@ class Filter:
         name = filter_info["name"]
         psf_fwhm = filter_info["psf_fwhm"] * u.arcsec
         zeropoint = filter_info["zeropoint"] * u.mag
-        extinction = filter_info["extinction"] * u.mag
         sky_brightness = filter_info["sky_brightness"] * (u.mag / u.arcsec ** 2)
         exposure_time = filter_info["exp_time"] * u.s
+        extinction = filter_info.get("extinction")
+        extinction = extinction if extinction is None else extinction * u.mag
         wavelength = filter_info.get("central_wavelength")
         wavelength = wavelength if wavelength is None else wavelength * u.nm
 
@@ -45,8 +46,8 @@ class Filter:
             name,
             psf_fwhm,
             zeropoint,
-            extinction,
             sky_brightness,
             exposure_time,
+            extinction,
             wavelength,
         )

--- a/galcheat/filter.py
+++ b/galcheat/filter.py
@@ -12,7 +12,6 @@ class Filter:
     zeropoint: Quantity
     sky_brightness: Quantity
     exposure_time: Quantity
-    extinction: Optional[Quantity] = None
     central_wavelength: Optional[Quantity] = None
 
     @classmethod
@@ -37,8 +36,6 @@ class Filter:
         zeropoint = filter_info["zeropoint"] * u.mag
         sky_brightness = filter_info["sky_brightness"] * (u.mag / u.arcsec ** 2)
         exposure_time = filter_info["exp_time"] * u.s
-        extinction = filter_info.get("extinction")
-        extinction = extinction if extinction is None else extinction * u.mag
         wavelength = filter_info.get("central_wavelength")
         wavelength = wavelength if wavelength is None else wavelength * u.nm
 
@@ -48,6 +45,5 @@ class Filter:
             zeropoint,
             sky_brightness,
             exposure_time,
-            extinction,
             wavelength,
         )


### PR DESCRIPTION
This PR was initiated after the DESC remote sprint week discussions mentioned in #38 and #39 and aims at updating the common set of parameters used for the surveys and the filters.

In particular we decided to
- remove the `effective_area` and compute it using the `obscuration` factor.
- remove the survey `airmass` and filter `extinction` which are pointing-dependent parameters
- add the `gain` information.
