### PR TITLE
Adding missing obscuration values

### DIFF
--- a/galcheat/data/CFHT.yaml
+++ b/galcheat/data/CFHT.yaml
@@ -3,13 +3,20 @@
 # gain
 # https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
 #
+# mirror_diameter
+# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/specsinformation.html (section 2.3)
+#
+# obscuration
+# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/specsinformation.html (section 2.3)
+# using the given effective area in cm^2, the obscuration is 1-80216/(pi*358*358/4)
+#
 # exp_time, fwhm: https://www.cfht.hawaii.edu/Science/CFHTLS/T0007/CFHTLS_T0007-TechnicalDocumentation.pdf
 # zeropoint: http://www1.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/community/CFHTLS-SG/docs/extra/filters.html
 name: "CFHT"
 pixel_scale: 0.187
 gain: 1.67
-effective_area: 8.022
-mirror_diameter: 3.592
+mirror_diameter: 3.58
+obscuration: 0.20309772
 zeropoint_airmass: 1.0
 filters:
   r:

--- a/galcheat/data/Euclid_VIS.yaml
+++ b/galcheat/data/Euclid_VIS.yaml
@@ -1,6 +1,12 @@
 # gain
 # https://www.mssl.ucl.ac.uk/~smn2/instrument.html
 #
+# mirror_diameter
+# https://arxiv.org/pdf/1608.08603.pdf (section 3.1)
+#
+# obscuration
+# https://arxiv.org/pdf/1608.08603.pdf (section 3.1)
+# 
 # Euclid definition study report: https://arxiv.org/abs/1110.3193
 # VIS PSF : https://ui.adsabs.harvard.edu/abs/2018SPIE10698E..28C
 # effective_area takes into account 13% obscuration: https://arxiv.org/abs/1608.08603
@@ -9,8 +15,8 @@
 name: "Euclid_VIS"
 pixel_scale: 0.10
 gain: 3.1
-effective_area: 0.98
 mirror_diameter: 1.2
+obscuration: 0.13
 filters:
   VIS:
     name: "VIS"

--- a/galcheat/data/Euclid_VIS.yaml
+++ b/galcheat/data/Euclid_VIS.yaml
@@ -6,7 +6,7 @@
 #
 # obscuration
 # https://arxiv.org/pdf/1608.08603.pdf (section 3.1)
-# 
+#
 # Euclid definition study report: https://arxiv.org/abs/1110.3193
 # VIS PSF : https://ui.adsabs.harvard.edu/abs/2018SPIE10698E..28C
 # effective_area takes into account 13% obscuration: https://arxiv.org/abs/1608.08603

--- a/galcheat/data/HST.yaml
+++ b/galcheat/data/HST.yaml
@@ -4,6 +4,12 @@
 # https://hst-docs.stsci.edu/acsihb/chapter-3-acs-capabilities-design-and-operations/3-5-acs-quick-reference-guide
 # https://iopscience.iop.org/article/10.1086/520086/pdf (page 1)
 #
+# mirror_diameter
+# https://arxiv.org/pdf/1203.0002.pdf (page 8)
+#
+# obscuration
+# https://arxiv.org/pdf/1203.0002.pdf (page 8)
+#
 # exp_time: https://hst-docs.stsci.edu/acsdhb/chapter-1-acs-overview/1-2-basic-instrument-operations
 # fwhm: https://hst-docs.stsci.edu/display/WFC3IHB/6.6+UVIS+Optical+Performance#id-6
 # zeropoint : https://galsim-developers.github.io/GalSim/_build/html/real_gal.html
@@ -11,8 +17,8 @@
 name: "HST_COSMOS"
 pixel_scale: 0.03
 gain: 1.0
-effective_area: 1.0 # TODO: placeholder
 mirror_diameter: 2.4
+obscuration: 0.33
 zeropoint_airmass: 0.0
 filters:
   f814w:

--- a/galcheat/data/Rubin.yaml
+++ b/galcheat/data/Rubin.yaml
@@ -1,12 +1,22 @@
 # gain
 # https://github.com/LSSTDESC/imSim/blob/main/imsim/stamp.py#L416
 #
+# mirror_diameter
+# https://www.lsst.org/about/tel-site/optical_design
+#
+# obscuration
+# the current value is computed from the effective area found in WLD
+# https://github.com/LSSTDESC/WeakLensingDeblending/blob/master/descwl/survey.py#L192
+# 1-32.4/(pi*8.36*8.36/4)
+# you can also find information at
+# https://github.com/aboucaud/galcheat/issues/38
+#
 # https://www.lsst.org/about/camera/features
 name: "Rubin"
 pixel_scale: 0.2
 gain: 1.0
-effective_area: 32.4
 mirror_diameter: 8.36
+obscuration: 0.40974106
 zeropoint_airmass: 1.2
 filters:
   u:


### PR DESCRIPTION
Here is the PR to add missing obscuration values #38 .

It is not perfectly clear for Rubin as the several sources I found give highly similar but still different values. I thus decided to compute it from the WLD effective that we have used until now.

For HSC we do not have the information yet so we will probably just update it later when we get it.