### PR TITLE
Euclid references

### DIFF
--- a/galcheat/data/Euclid_VIS.yaml
+++ b/galcheat/data/Euclid_VIS.yaml
@@ -1,3 +1,6 @@
+# pixel_scale
+# https://arxiv.org/pdf/1110.3193.pdf (page 3)
+#
 # gain
 # https://www.mssl.ucl.ac.uk/~smn2/instrument.html
 #
@@ -7,11 +10,22 @@
 # obscuration
 # https://arxiv.org/pdf/1608.08603.pdf (section 3.1)
 #
-# Euclid definition study report: https://arxiv.org/abs/1110.3193
-# VIS PSF : https://ui.adsabs.harvard.edu/abs/2018SPIE10698E..28C
-# effective_area takes into account 13% obscuration: https://arxiv.org/abs/1608.08603
-# exposure_time: https://arxiv.org/abs/1608.08603
-# sky brightness: http://www.mssl.ucl.ac.uk/~smn2/instrument.html
+# sky_brightness
+# https://www.mssl.ucl.ac.uk/~smn2/instrument.html
+#
+# exposure_time
+# https://arxiv.org/pdf/1608.08603.pdf (section 6)
+#
+# zeropoint
+# computed with speclite: I guess we should add a reference to a shared speclite
+# resource among surveys once we have it
+#
+# psf_fwhm
+# https://arxiv.org/pdf/1608.08603.pdf (section 8)
+#
+# central_wavelength
+# value from BTK and WLD
+
 name: "Euclid_VIS"
 pixel_scale: 0.10
 gain: 3.1

--- a/galcheat/data/Euclid_VIS.yaml
+++ b/galcheat/data/Euclid_VIS.yaml
@@ -10,6 +10,9 @@
 # obscuration
 # https://arxiv.org/pdf/1608.08603.pdf (section 3.1)
 #
+# zeropoint_airmass
+# space telescope
+#
 # sky_brightness
 # https://www.mssl.ucl.ac.uk/~smn2/instrument.html
 #
@@ -31,6 +34,7 @@ pixel_scale: 0.10
 gain: 3.1
 mirror_diameter: 1.2
 obscuration: 0.13
+zeropoint_airmass: 0.0
 filters:
   VIS:
     name: "VIS"

--- a/galcheat/data/Euclid_VIS.yaml
+++ b/galcheat/data/Euclid_VIS.yaml
@@ -17,8 +17,8 @@
 # https://arxiv.org/pdf/1608.08603.pdf (section 6)
 #
 # zeropoint
-# computed with speclite: I guess we should add a reference to a shared speclite
-# resource among surveys once we have it
+# computed with speclite: for more information you may want to check
+# https://github.com/aboucaud/galcheat/issues/48 and the zeropoints.py script
 #
 # psf_fwhm
 # https://arxiv.org/pdf/1608.08603.pdf (section 8)


### PR DESCRIPTION
This PR aims to update the Euclid references, related to issue #27.

Almost all is ok, except for:
* The speclite `zeropoint` common reference that we need to make #48.
* The `central_wavelength` reference. The current value comes from BTK and WLD, itself coming from [LSST throughputs](https://github.com/lsst/throughputs). But I do not find the Euclid filters there. Instead, we may want to double check the value using the [Euclid speclite filter responses](https://speclite.readthedocs.io/en/latest/filters.html#euclid-filters), once we get confirmation about the way to compute it #36.