### PR TITLE
HST_COSMOS references

### DIFF
--- a/galcheat/data/HST.yaml
+++ b/galcheat/data/HST.yaml
@@ -1,19 +1,27 @@
-# pixel_scale: https://hst-docs.stsci.edu/acsihb/chapter-3-acs-capabilities-design-and-operations/3-5-acs-quick-reference-guide
+# pixel_scale
+# https://iopscience.iop.org/article/10.1086/520086/pdf (section 4)
 #
 # gain
-# https://hst-docs.stsci.edu/acsihb/chapter-3-acs-capabilities-design-and-operations/3-5-acs-quick-reference-guide
-# https://iopscience.iop.org/article/10.1086/520086/pdf (page 1)
+# https://iopscience.iop.org/article/10.1086/520086/pdf (section 2.1)
 #
 # mirror_diameter
-# https://arxiv.org/pdf/1203.0002.pdf (page 8)
+# https://arxiv.org/pdf/1203.0002.pdf (section 4 table 1)
 #
 # obscuration
-# https://arxiv.org/pdf/1203.0002.pdf (page 8)
+# https://arxiv.org/pdf/1203.0002.pdf (section 4 table 1)
 #
-# exposure_time: https://hst-docs.stsci.edu/acsdhb/chapter-1-acs-overview/1-2-basic-instrument-operations
-# fwhm: https://hst-docs.stsci.edu/display/WFC3IHB/6.6+UVIS+Optical+Performance#id-6
-# zeropoint : https://galsim-developers.github.io/GalSim/_build/html/real_gal.html
-# .6UVISOpticalPerformance-6.6.1 800nm
+# sky_brightness
+#
+#
+# exposure_time
+# https://iopscience.iop.org/article/10.1086/520086/pdf (section 2.2)
+#
+# zeropoint
+# https://galsim-developers.github.io/GalSim/_build/html/real_gal.html
+#
+# psf_fwhm
+# https://iopscience.iop.org/article/10.1086/520086/pdf (section 5)
+
 name: "HST_COSMOS"
 pixel_scale: 0.03
 gain: 1.0
@@ -26,4 +34,4 @@ filters:
     sky_brightness: 22
     exposure_time: 2028
     zeropoint: 25.94
-    psf_fwhm: 0.074
+    psf_fwhm: 0.095


### PR DESCRIPTION
Here is the update of HST_COSMOS survey parameters.

As stated in #40, I could not find a reference for the `sky_brightness` value yet.