### PR TITLE
CFHT references

### DIFF
--- a/galcheat/data/CFHT.yaml
+++ b/galcheat/data/CFHT.yaml
@@ -1,4 +1,5 @@
-# pixel_scale, sky_brightness: http://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
+# pixel_scale
+# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
 #
 # gain
 # https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
@@ -10,8 +11,20 @@
 # https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/specsinformation.html (section 2.3)
 # using the given effective area in cm^2, the obscuration is 1-80216/(pi*358*358/4)
 #
-# exposure_time, fwhm: https://www.cfht.hawaii.edu/Science/CFHTLS/T0007/CFHTLS_T0007-TechnicalDocumentation.pdf
-# zeropoint: http://www1.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/community/CFHTLS-SG/docs/extra/filters.html
+# sky_brightness
+# http://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
+# taken as "grey sky": at zenith, 30% moon
+#
+# exposure_time
+# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
+#
+# zeropoint
+# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
+#
+# psf_fwhm
+# https://www.cfht.hawaii.edu/Science/CFHTLS/T0007/CFHTLS_T0007-TechnicalDocumentation.pdf
+# roughly taken from figure 25
+
 name: "CFHT"
 pixel_scale: 0.187
 gain: 1.67
@@ -19,15 +32,33 @@ mirror_diameter: 3.58
 obscuration: 0.20309772
 zeropoint_airmass: 1.0
 filters:
+  u:
+    name: "u"
+    sky_brightness: 21.20
+    exposure_time: 300
+    zeropoint: 25.78
+    psf_fwhm: 0.81
+  g:
+    name: "g"
+    sky_brightness: 21.30
+    exposure_time: 300
+    zeropoint: 27.11
+    psf_fwhm: 0.84
   r:
     name: "r"
-    sky_brightness: 20.8
-    exposure_time: 2000
+    sky_brightness: 20.80
+    exposure_time: 300
     zeropoint: 26.74
-    psf_fwhm: 0.71
+    psf_fwhm: 0.73
   i:
     name: "i"
-    sky_brightness: 20.3
-    exposure_time: 4300
+    sky_brightness: 20.30
+    exposure_time: 300
     zeropoint: 26.22
-    psf_fwhm: 0.64
+    psf_fwhm: 0.66
+  z:
+    name: "z"
+    sky_brightness: 19.40
+    exposure_time: 300
+    zeropoint: 25.05
+    psf_fwhm: 0.66

--- a/galcheat/data/CFHT.yaml
+++ b/galcheat/data/CFHT.yaml
@@ -16,7 +16,8 @@
 # taken as "grey sky": at zenith, 30% moon
 #
 # exposure_time
-# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
+# https://www.cfht.hawaii.edu/Science/CFHTLS/T0007/CFHTLS_T0007-TechnicalDocumentation.pdf
+# taken as modes in table 31
 #
 # zeropoint
 # https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
@@ -35,30 +36,30 @@ filters:
   u:
     name: "u"
     sky_brightness: 21.20
-    exposure_time: 300
+    exposure_time: 3000
     zeropoint: 25.78
     psf_fwhm: 0.81
   g:
     name: "g"
     sky_brightness: 21.30
-    exposure_time: 300
+    exposure_time: 2500
     zeropoint: 27.11
     psf_fwhm: 0.84
   r:
     name: "r"
     sky_brightness: 20.80
-    exposure_time: 300
+    exposure_time: 2000
     zeropoint: 26.74
     psf_fwhm: 0.73
   i:
     name: "i"
     sky_brightness: 20.30
-    exposure_time: 300
+    exposure_time: 4305
     zeropoint: 26.22
     psf_fwhm: 0.66
   z:
     name: "z"
     sky_brightness: 19.40
-    exposure_time: 300
+    exposure_time: 3600
     zeropoint: 25.05
     psf_fwhm: 0.66

--- a/galcheat/data/CFHTLS.yaml
+++ b/galcheat/data/CFHTLS.yaml
@@ -26,7 +26,7 @@
 # https://www.cfht.hawaii.edu/Science/CFHTLS/T0007/CFHTLS_T0007-TechnicalDocumentation.pdf
 # roughly taken from figure 25
 
-name: "CFHT"
+name: "CFHTLS"
 pixel_scale: 0.187
 gain: 1.67
 mirror_diameter: 3.58


### PR DESCRIPTION
Here are updates concerning CFHT #28.

I completed the filters to u, g, r, i, z. Most references come from the [CFHT-MegaCam general information page](https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html) but the `psf_fwhm` is from [CFHTLS](https://www.cfht.hawaii.edu/Science/CFHTLS/T0007/CFHTLS_T0007-TechnicalDocumentation.pdf) because I could not find it elsewhere.
So I was wondering if we should prefer general CFHT or CFHTLS parameters ? For instance, we could set CFHTLS exposure times instead of the current 300s. But if we go for this I guess we should change the survey name to CFHTLS. What do you think ? 
I ping @aguinot as you surely have an opinion about this !