### PR TITLE
Zeropoint and zeropoint_airmass references

### DIFF
--- a/galcheat/data/CFHTLS.yaml
+++ b/galcheat/data/CFHTLS.yaml
@@ -11,6 +11,9 @@
 # https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/specsinformation.html (section 2.3)
 # using the given effective area in cm^2, the obscuration is 1-80216/(pi*358*358/4)
 #
+# zeropoint_airmass
+# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
+#
 # sky_brightness
 # http://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
 # taken as "grey sky": at zenith, 30% moon

--- a/galcheat/data/DES.yaml
+++ b/galcheat/data/DES.yaml
@@ -12,6 +12,9 @@
 # disk of 1.651m so that the obscuration is 1.651^2/3.934^2
 # which gives back the 10.014m² effective area given by the webpage
 #
+# zeropoint_airmass
+# https://speclite.readthedocs.io/en/latest/filters.html#decam-2014-filters
+#
 # sky brightness
 # https://arxiv.org/pdf/1801.03181.pdf (table 1)
 #
@@ -20,8 +23,8 @@
 # coadds of 10 90s exposures from section 2.2 page 5
 #
 # zeropoint
-# computed with speclite: I guess we should add a reference to a shared speclite
-# resource among surveys once we have it
+# computed with speclite: for more information you may want to check
+# https://github.com/aboucaud/galcheat/issues/48 and the zeropoints.py script
 #
 # psf_fwhm
 # https://arxiv.org/pdf/1801.03181.pdf (table 1)
@@ -31,7 +34,7 @@ pixel_scale: 0.2637
 gain: 4.0
 mirror_diameter: 3.934
 obscuration: 0.17612680
-zeropoint_airmass: 1.2
+zeropoint_airmass: 1.3
 filters:
   g:
     name: "g"

--- a/galcheat/data/HSC.yaml
+++ b/galcheat/data/HSC.yaml
@@ -14,6 +14,9 @@
 # https://subarutelescope.org/Observing/Telescope/Parameters/
 # https://subarutelescope.org/en/about/
 #
+# zeropoint_aimass
+# https://speclite.readthedocs.io/en/latest/filters.html#hsc-filters
+#
 # exposure_time and psf_fwhm
 # "Wide" in Table 1 of the HSC PDR3 paper (https://arxiv.org/pdf/2108.13045.pdf)
 #
@@ -26,28 +29,9 @@
 # could update the numbers to this version, although we need to
 # convert the unit from ADU/sec to mag/arcsec^2.
 #
-# zeropoint and zeropoint_airmass
-# The zeropoints are inhereted from WeakLensingDeblending
-# (https://github.com/LSSTDESC/WeakLensingDeblending/blob/master/descwl/survey.py#L315).
-# In WeakLensingDeblending, a zeropoint is defined with respect to mag = 24 as
-# flux = exposure_time * Z_{24} * 10^(-0.4 * (mag-24))
-# , but here we converted it to a more useful convention
-# flux = exposure_time * 10^(-0.4 * (mag-Z))
-# . Note that it assumes an atmosphere airmass of 1.2.
-# We found that our zeropoints are close to the ones in the Subaru
-# website (see mag for 1e-/s in
-# https://www.naoj.org/Observing/Instruments/HSC/sensitivity.html).
-# Note:
-# The zeropoints in WeakLensingDeblending used the speclite package
-# (https://github.com/desihub/speclite), where they seemed to use the
-# official filter responses
-# (https://speclite.readthedocs.io/en/latest/filters.html#hsc-filters)
-# and convolved them with a reference magnitude
-# (https://speclite.readthedocs.io/en/latest/api/speclite.filters.ab_reference_flux.html#speclite.filters.ab_reference_flux)
-# to obtain the zeropoints.
-# You may find detailed discussions at
-# - https://github.com/LSSTDESC/WeakLensingDeblending/issues/19
-# - https://github.com/aboucaud/galcheat/pull/32
+# zeropoint
+# computed with speclite: for more information you may want to check
+# https://github.com/aboucaud/galcheat/issues/48 and the zeropoints.py script
 
 name: HSC
 pixel_scale: 0.168

--- a/galcheat/data/HST.yaml
+++ b/galcheat/data/HST.yaml
@@ -10,6 +10,9 @@
 # obscuration
 # https://arxiv.org/pdf/1203.0002.pdf (section 4 table 1)
 #
+# zeropoint_airmass
+# space telescope
+#
 # sky_brightness
 #
 #

--- a/galcheat/data/Rubin.yaml
+++ b/galcheat/data/Rubin.yaml
@@ -11,7 +11,15 @@
 # you can also find information at
 # https://github.com/aboucaud/galcheat/issues/38
 #
+# zeropoint_airmass
+# https://speclite.readthedocs.io/en/latest/filters.html#lsst-filters
+#
 # https://www.lsst.org/about/camera/features
+#
+# zeropoint
+# computed with speclite: for more information you may want to check
+# https://github.com/aboucaud/galcheat/issues/48 and the zeropoints.py script
+
 name: "Rubin"
 pixel_scale: 0.2
 gain: 1.0


### PR DESCRIPTION
This PR aims to update the `zeropoint` references (especially the speclite ones) and to add the `zeropoint_airmass` references that were missing.

(I did not update Euclid as it is done in its corresponding PR #49) 