### PR TITLE
Add effective wavelength script

### DIFF
--- a/scripts/effective_wavelengths.py
+++ b/scripts/effective_wavelengths.py
@@ -1,0 +1,37 @@
+from speclite.filters import load_filter
+
+from galcheat import available_surveys, get_survey
+
+speclite_survey_prefixes = {
+    "DES": "decam2014-",
+    "Euclid_VIS": "Euclid-",
+    "HSC": "hsc2017-",
+    "Rubin": "lsst2016-",
+}
+
+
+def check_effective_wavelengths(survey_name):
+    """Check the current effective wavelengths with speclite
+    and compare them to their current values
+    """
+
+    if survey_name in speclite_survey_prefixes.keys():
+        survey = get_survey(survey_name)
+        print(survey_name, ":")
+
+        speclite_prefix = speclite_survey_prefixes[survey_name]
+
+        for filt_name in survey.available_filters:
+            speclite_filt_name = f"{speclite_prefix}{filt_name}"
+            speclite_filt = load_filter(speclite_filt_name)
+            speclite_eff_wl = speclite_filt.effective_wavelength
+            # galcheat_eff_wl = survey.get_filter(filt_name).effective_wavelength
+            print(f"  Filter {filt_name} ({speclite_filt_name} in speclite)")
+            print(f"    Speclite effective wavelength: {speclite_eff_wl:.2f}")
+    else:
+        print(survey_name, ": filters are not available in speclite")
+
+
+if __name__ == "__main__":
+    for survey_name in available_surveys:
+        check_effective_wavelengths(survey_name)


### PR DESCRIPTION
Here is the PR related to effective wavelengths and #36.

As mentioned in the issue, speclite provides an `effective_wavelength` for each filter. For now I just wrote a small `effective_wavelengths.py` script similarly to `zeropoints.py`. What do you think of using those values @aboucaud @ismael-mendoza ?

Note that even if we use those speclite effective wavelengths, we would need to find them for the surveys not included in speclite (CFHTLS and HST).