### PR TITLE
Make references printable

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
         python -m galcheat
     - name: Test the console script
       run: |
-        galcheat
+        galcheat --refs
     - name: Test the scripts
       run: |
         for pyscript in scripts/*.py; do python ${pyscript}; done

--- a/README.md
+++ b/README.md
@@ -21,20 +21,37 @@ The goal of this project is to provide a Python library with minimal dependencie
 
 The current parameters and the corresponding units are specified in the [data README](galcheat/data/README.md)
 
-[**Getting started**](#getting-started) | [**API**](#api) | [**Contributing**](#contributing) | [**License**](#license)
+[**Getting started**](#getting-started) | [**CLI**](#cli) | [**API**](#api) | [**Contributing**](#contributing) | [**License**](#license)
 
 Getting started
 ---------------
-1.  Install the latest version of the library
-    ```sh
-    pip install -U galcheat
-    ```
-2. Run the demo = print the available surveys and associated filters
-    ```sh
-    python -m galcheat
-    # or
-    galcheat
-    ```
+Install the latest version of the library
+```sh
+pip install -U galcheat
+```
+
+CLI
+---
+
+Print the available surveys and associated filters
+
+```sh
+python -m galcheat
+# or
+galcheat
+```
+
+### Options
+- **`-s <survey>`**: print information for a given survey
+- **`--refs`**: print the source for each parameter
+- **`-h, --help`**: get help
+
+### Exemples
+```sh
+galcheat -s LSST        # LSST info
+galcheat --refs         # all surveys info with refs
+galcheat --refs -s HSC  # HSC info with refs
+```
 
 API
 ---

--- a/galcheat/__main__.py
+++ b/galcheat/__main__.py
@@ -18,6 +18,12 @@ def _survey_parser():
         dest="survey_name",
         help="Name of survey. If None, shows all available surveys.",
     )
+    parser.add_argument(
+        "--refs",
+        action="store_true",
+        dest="show_refs",
+        help="Print the references for each parameter.",
+    )
     return parser.parse_args()
 
 
@@ -26,11 +32,11 @@ def main():
 
     if args.survey_name is None:
         for survey in available_surveys:
-            print_survey(survey)
+            print_survey(survey, show_refs=args.show_refs)
             print(_LINEBREAK)
     else:
         try:
-            print_survey(args.survey_name)
+            print_survey(args.survey_name, show_refs=args.show_refs)
         except ValueError as e:
             print(e)
     print(_FOOTER)

--- a/galcheat/data/CFHTLS.yaml
+++ b/galcheat/data/CFHTLS.yaml
@@ -1,37 +1,3 @@
-# pixel_scale
-# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
-#
-# gain
-# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
-#
-# mirror_diameter
-# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/specsinformation.html (section 2.3)
-#
-# obscuration
-# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/specsinformation.html (section 2.3)
-# using the given effective area in cm^2, the obscuration is 1-80216/(pi*358*358/4)
-#
-# zeropoint_airmass
-# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
-#
-# sky_brightness
-# http://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
-# taken as "grey sky": at zenith, 30% moon
-#
-# exposure_time
-# https://www.cfht.hawaii.edu/Science/CFHTLS/T0007/CFHTLS_T0007-TechnicalDocumentation.pdf
-# taken as modes in table 31
-#
-# zeropoint
-# https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html
-#
-# psf_fwhm
-# https://www.cfht.hawaii.edu/Science/CFHTLS/T0007/CFHTLS_T0007-TechnicalDocumentation.pdf
-# roughly taken from figure 25
-#
-# effective_wavelength
-# https://cosmos.astro.caltech.edu/page/filterset
-
 name: "CFHTLS"
 description: "Canada France Hawaii Lensing wide-field Survey (CFHTLS) done with the Canada France Hawaii Telescope (CFHT) and MegaCam"
 pixel_scale: 0.187
@@ -75,3 +41,34 @@ filters:
     zeropoint: 25.05
     psf_fwhm: 0.66
     effective_wavelength: 882.798
+references:
+  pixel_scale:
+    link: "https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html"
+    comment: ""
+  gain:
+    link: "https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html"
+    comment: ""
+  mirror_diameter:
+    link: "https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/specsinformation.html"
+    comment: "See section 2.3"
+  obscuration:
+    link: "https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/specsinformation.html"
+    comment: "See section 2.3, using the given effective area in cm^2, the obscuration is 1-80216/(pi*358*358/4)"
+  zeropoint_airmass:
+    link: "https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html"
+    comment: ""
+  sky_brightness:
+    link: "https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html"
+    comment: "taken as \"grey sky\": at zenith, 30% moon"
+  exposure_time:
+    link: "https://www.cfht.hawaii.edu/Science/CFHTLS/T0007/CFHTLS_T0007-TechnicalDocumentation.pdf"
+    comment: "taken as modes in table 31"
+  zeropoint:
+    link: "https://www.cfht.hawaii.edu/Instruments/Imaging/Megacam/generalinformation.html"
+    comment: ""
+  psf_fwhm:
+    link: "https://www.cfht.hawaii.edu/Science/CFHTLS/T0007/CFHTLS_T0007-TechnicalDocumentation.pdf"
+    comment: "roughly taken from figure 25"
+  effective_wavelength:
+    link: "https://cosmos.astro.caltech.edu/page/filterset"
+    comment: ""

--- a/galcheat/data/COSMOS.yaml
+++ b/galcheat/data/COSMOS.yaml
@@ -43,3 +43,34 @@ filters:
     zeropoint: 25.94
     psf_fwhm: 0.095
     effective_wavelength: 807.343
+references:
+  pixel_scale:
+    link: ""
+    comment: ""
+  gain:
+    link: ""
+    comment: ""
+  mirror_diameter:
+    link: ""
+    comment: ""
+  obscuration:
+    link: ""
+    comment: ""
+  zeropoint_airmass:
+    link: ""
+    comment: ""
+  sky_brightness:
+    link: ""
+    comment: ""
+  exposure_time:
+    link: ""
+    comment: ""
+  zeropoint:
+    link: ""
+    comment: ""
+  psf_fwhm:
+    link: ""
+    comment: ""
+  effective_wavelength:
+    link: ""
+    comment: ""

--- a/galcheat/data/COSMOS.yaml
+++ b/galcheat/data/COSMOS.yaml
@@ -1,33 +1,3 @@
-# pixel_scale
-# https://iopscience.iop.org/article/10.1086/520086/pdf (section 4)
-#
-# gain
-# https://iopscience.iop.org/article/10.1086/520086/pdf (section 2.1)
-#
-# mirror_diameter
-# https://arxiv.org/pdf/1203.0002.pdf (section 4 table 1)
-#
-# obscuration
-# https://arxiv.org/pdf/1203.0002.pdf (section 4 table 1)
-#
-# zeropoint_airmass
-# space telescope
-#
-# sky_brightness
-#
-#
-# exposure_time
-# https://iopscience.iop.org/article/10.1086/520086/pdf (section 2.2)
-#
-# zeropoint
-# https://galsim-developers.github.io/GalSim/_build/html/real_gal.html
-#
-# psf_fwhm
-# https://iopscience.iop.org/article/10.1086/520086/pdf (section 5)
-#
-# effective_wavelength
-# https://cosmos.astro.caltech.edu/page/filterset
-
 name: "COSMOS"
 description: "COSMOS survey done with the Hubble Space Telescope (HST) and the Advanced Camera for Surveys (ACS)"
 pixel_scale: 0.03
@@ -45,32 +15,32 @@ filters:
     effective_wavelength: 807.343
 references:
   pixel_scale:
-    link: ""
-    comment: ""
+    link: " https://iopscience.iop.org/article/10.1086/520086/pdf"
+    comment: "See section 4"
   gain:
-    link: ""
-    comment: ""
+    link: " https://iopscience.iop.org/article/10.1086/520086/pdf"
+    comment: "See section 2.1"
   mirror_diameter:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/1203.0002.pdf"
+    comment: "See section 4 table 1"
   obscuration:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/1203.0002.pdf"
+    comment: "See section 4 table 1"
   zeropoint_airmass:
     link: ""
-    comment: ""
+    comment: "Space telescope"
   sky_brightness:
     link: ""
     comment: ""
   exposure_time:
-    link: ""
-    comment: ""
+    link: "https://iopscience.iop.org/article/10.1086/520086/pdf"
+    comment: "See section 2.2"
   zeropoint:
-    link: ""
+    link: "https://galsim-developers.github.io/GalSim/_build/html/real_gal.html"
     comment: ""
   psf_fwhm:
-    link: ""
-    comment: ""
+    link: "https://iopscience.iop.org/article/10.1086/520086/pdf"
+    comment: "See section 5"
   effective_wavelength:
-    link: ""
+    link: "https://cosmos.astro.caltech.edu/page/filterset"
     comment: ""

--- a/galcheat/data/DES.yaml
+++ b/galcheat/data/DES.yaml
@@ -1,38 +1,3 @@
-# pixel_scale
-# http://www.ctio.noirlab.edu/noao/content/DECam-What
-#
-# gain
-# http://www.ctio.noirlab.edu/noao/content/DECam-What
-#
-# mirror_diameter
-# http://www.ctio.noirlab.edu/noao/content/Basic-Optical-Parameters
-#
-# obscuration
-# http://www.ctio.noirlab.edu/noao/content/Basic-Optical-Parameters
-# disk of 1.651m so that the obscuration is 1.651^2/3.934^2
-# which gives back the 10.014m² effective area given by the webpage
-#
-# zeropoint_airmass
-# https://speclite.readthedocs.io/en/latest/filters.html#decam-2014-filters
-#
-# sky_brightness
-# https://arxiv.org/pdf/1801.03181.pdf (table 1)
-#
-# exposure_time
-# https://arxiv.org/pdf/1801.03181.pdf
-# coadds of 10 90s exposures from section 2.2 page 5
-#
-# zeropoint
-# computed with speclite: for more information you may want to check
-# https://github.com/aboucaud/galcheat/issues/48 and the zeropoints.py script
-#
-# psf_fwhm
-# https://arxiv.org/pdf/1801.03181.pdf (table 1)
-#
-# effective_wavelength
-# computed with speclite: for more information you may want to check
-# https://github.com/aboucaud/galcheat/issues/36 and the effective_wavelengths.py script
-
 name: "DES"
 description: "Dark Energy wide-field Survey (DES) done with the Victor M. Blanco telescope and the Dark Energy CAMera (DECam)"
 pixel_scale: 0.2637
@@ -71,32 +36,32 @@ filters:
     effective_wavelength: 919.646
 references:
   pixel_scale:
-    link: ""
+    link: "http://www.ctio.noirlab.edu/noao/content/DECam-What"
     comment: ""
   gain:
-    link: ""
+    link: "http://www.ctio.noirlab.edu/noao/content/DECam-What"
     comment: ""
   mirror_diameter:
-    link: ""
+    link: "http://www.ctio.noirlab.edu/noao/content/Basic-Optical-Parameters"
     comment: ""
   obscuration:
-    link: ""
-    comment: ""
+    link: "http://www.ctio.noirlab.edu/noao/content/Basic-Optical-Parameters"
+    comment: "disk of 1.651m - obscuration is 1.651^2/3.934^2 which returns the right effective area"
   zeropoint_airmass:
-    link: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html#decam-2014-filters"
     comment: ""
   sky_brightness:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/1801.03181.pdf"
+    comment: "See table 1"
   exposure_time:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/1801.03181.pdf"
+    comment: "See section 2.2 page 5. Coadds of 10 x 90s exposures"
   zeropoint:
-    link: ""
-    comment: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html#decam-2014-filters"
+    comment: "computed with speclite – see scripts/check_zeropoints.py"
   psf_fwhm:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/1801.03181.pdf"
+    comment: "See table 1"
   effective_wavelength:
-    link: ""
-    comment: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html#decam-2014-filters"
+    comment: "computed with speclite – see scripts/check_effective_wavelength.py"

--- a/galcheat/data/DES.yaml
+++ b/galcheat/data/DES.yaml
@@ -69,3 +69,34 @@ filters:
     zeropoint: 26.58
     psf_fwhm: 0.84
     effective_wavelength: 919.646
+references:
+  pixel_scale:
+    link: ""
+    comment: ""
+  gain:
+    link: ""
+    comment: ""
+  mirror_diameter:
+    link: ""
+    comment: ""
+  obscuration:
+    link: ""
+    comment: ""
+  zeropoint_airmass:
+    link: ""
+    comment: ""
+  sky_brightness:
+    link: ""
+    comment: ""
+  exposure_time:
+    link: ""
+    comment: ""
+  zeropoint:
+    link: ""
+    comment: ""
+  psf_fwhm:
+    link: ""
+    comment: ""
+  effective_wavelength:
+    link: ""
+    comment: ""

--- a/galcheat/data/Euclid_VIS.yaml
+++ b/galcheat/data/Euclid_VIS.yaml
@@ -45,3 +45,34 @@ filters:
     zeropoint: 25.91
     psf_fwhm: 0.17
     effective_wavelength: 750.637
+references:
+  pixel_scale:
+    link: ""
+    comment: ""
+  gain:
+    link: ""
+    comment: ""
+  mirror_diameter:
+    link: ""
+    comment: ""
+  obscuration:
+    link: ""
+    comment: ""
+  zeropoint_airmass:
+    link: ""
+    comment: ""
+  sky_brightness:
+    link: ""
+    comment: ""
+  exposure_time:
+    link: ""
+    comment: ""
+  zeropoint:
+    link: ""
+    comment: ""
+  psf_fwhm:
+    link: ""
+    comment: ""
+  effective_wavelength:
+    link: ""
+    comment: ""

--- a/galcheat/data/Euclid_VIS.yaml
+++ b/galcheat/data/Euclid_VIS.yaml
@@ -1,35 +1,3 @@
-# pixel_scale
-# https://arxiv.org/pdf/1110.3193.pdf (page 3)
-#
-# gain
-# https://www.mssl.ucl.ac.uk/~smn2/instrument.html
-#
-# mirror_diameter
-# https://arxiv.org/pdf/1608.08603.pdf (section 3.1)
-#
-# obscuration
-# https://arxiv.org/pdf/1608.08603.pdf (section 3.1)
-#
-# zeropoint_airmass
-# space telescope
-#
-# sky_brightness
-# https://www.mssl.ucl.ac.uk/~smn2/instrument.html
-#
-# exposure_time
-# https://arxiv.org/pdf/1608.08603.pdf (section 6)
-#
-# zeropoint
-# computed with speclite: for more information you may want to check
-# https://github.com/aboucaud/galcheat/issues/48 and the zeropoints.py script
-#
-# psf_fwhm
-# https://arxiv.org/pdf/1608.08603.pdf (section 8)
-#
-# effective_wavelength
-# computed with speclite: for more information you may want to check
-# https://github.com/aboucaud/galcheat/issues/36 and the effective_wavelengths.py script
-
 name: "Euclid_VIS"
 description: "Euclid wide-field survey done with the Euclid space telescope and the visible instrument (VIS)"
 pixel_scale: 0.10
@@ -47,32 +15,32 @@ filters:
     effective_wavelength: 750.637
 references:
   pixel_scale:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/1110.3193.pdf"
+    comment: "See page 3"
   gain:
-    link: ""
+    link: "https://www.mssl.ucl.ac.uk/~smn2/instrument.html"
     comment: ""
   mirror_diameter:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/1608.08603.pdf"
+    comment: "See section 3.1"
   obscuration:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/1608.08603.pdf"
+    comment: "See section 3.1"
   zeropoint_airmass:
     link: ""
-    comment: ""
+    comment: "Space telescope"
   sky_brightness:
-    link: ""
+    link: "https://www.mssl.ucl.ac.uk/~smn2/instrument.html"
     comment: ""
   exposure_time:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/1608.08603.pdf"
+    comment: "See section 6"
   zeropoint:
-    link: ""
-    comment: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html"
+    comment: "computed with speclite – see scripts/check_zeropoints.py"
   psf_fwhm:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/1608.08603.pdf"
+    comment: "See section 8"
   effective_wavelength:
-    link: ""
-    comment: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html"
+    comment: "computed with speclite – see scripts/check_effective_wavelength.py"

--- a/galcheat/data/HSC.yaml
+++ b/galcheat/data/HSC.yaml
@@ -83,3 +83,34 @@ filters:
     zeropoint: 27.33
     psf_fwhm: 0.68
     effective_wavelength: 978.695
+references:
+  pixel_scale:
+    link: ""
+    comment: ""
+  gain:
+    link: ""
+    comment: ""
+  mirror_diameter:
+    link: ""
+    comment: ""
+  obscuration:
+    link: ""
+    comment: ""
+  zeropoint_airmass:
+    link: ""
+    comment: ""
+  sky_brightness:
+    link: ""
+    comment: ""
+  exposure_time:
+    link: ""
+    comment: ""
+  zeropoint:
+    link: ""
+    comment: ""
+  psf_fwhm:
+    link: ""
+    comment: ""
+  effective_wavelength:
+    link: ""
+    comment: ""

--- a/galcheat/data/HSC.yaml
+++ b/galcheat/data/HSC.yaml
@@ -1,45 +1,3 @@
-# pixel_scale
-# https://hsc-release.mtk.nao.ac.jp/doc/index.php/survey/
-#
-# gain
-# https://www.naoj.org/Observing/Instruments/HSC/parameters.html
-#
-# mirror_diameter
-# https://carlkop.home.xs4all.nl/subaru.html#:~:text=The%20National%20Astronomical%20Observatory%20of,construction%20atop%20Mauna%20Kea%2C%20Hawaii.
-#
-# obscuration
-# https://carlkop.home.xs4all.nl/subaru.html#:~:text=The%20National%20Astronomical%20Observatory%20of,construction%20atop%20Mauna%20Kea%2C%20Hawaii.
-# central hole of 1.2m so that the obscuration is 1.2^2/8.3^2 (confirmed by an expert contacted by H. Miyatake)
-# which is consistent with the 8.2 effective diameter value that can be found in many places
-# https://subarutelescope.org/Observing/Telescope/Parameters/
-# https://subarutelescope.org/en/about/
-#
-# zeropoint_aimass
-# https://speclite.readthedocs.io/en/latest/filters.html#hsc-filters
-#
-# sky_brightness
-# https://www.naoj.org/Observing/Instruments/SCam/exptime.html.
-# Note:
-# The link is for Suprime-Cam, which should be approximately
-# okay. Here is the updated version for HSC as of July 2021
-# https://www.subarutelescope.org/Observing/Instruments/HSC/hsc_etc_report.html. We
-# could update the numbers to this version, although we need to
-# convert the unit from ADU/sec to mag/arcsec^2.
-#
-# exposure_time
-# "Wide" in Table 1 of the HSC PDR3 paper (https://arxiv.org/pdf/2108.13045.pdf)
-#
-# zeropoint
-# computed with speclite: for more information you may want to check
-# https://github.com/aboucaud/galcheat/issues/48 and the zeropoints.py script
-#
-# psf_fwhm
-# "Wide" in Table 1 of the HSC PDR3 paper (https://arxiv.org/pdf/2108.13045.pdf)
-#
-# effective_wavelength
-# computed with speclite: for more information you may want to check
-# https://github.com/aboucaud/galcheat/issues/36 and the effective_wavelengths.py script
-
 name: "HSC"
 description: "Hyper Suprime-Cam (HSC) wide-field survey done with the Subaru telescope and the Hyper Suprime-Cam (HSC)"
 pixel_scale: 0.168
@@ -85,32 +43,40 @@ filters:
     effective_wavelength: 978.695
 references:
   pixel_scale:
-    link: ""
+    link: "https://hsc-release.mtk.nao.ac.jp/doc/index.php/survey/"
     comment: ""
   gain:
-    link: ""
+    link: "https://www.naoj.org/Observing/Instruments/HSC/parameters.html"
     comment: ""
   mirror_diameter:
-    link: ""
+    link: "https://carlkop.home.xs4all.nl/subaru.html"
     comment: ""
   obscuration:
-    link: ""
-    comment: ""
+    link: "https://carlkop.home.xs4all.nl/subaru.html"
+    comment: "central hole of 1.2m so that the obscuration is 1.2^2/8.3^2 (confirmed by an expert contacted by H. Miyatake)"
   zeropoint_airmass:
-    link: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html#hsc-filters"
     comment: ""
   sky_brightness:
-    link: ""
+    link: "https://www.naoj.org/Observing/Instruments/SCam/exptime.html"
     comment: ""
   exposure_time:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/2108.13045.pdf"
+    comment: "See \"Wide\" in table 1"
   zeropoint:
-    link: ""
-    comment: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html#hsc-filters"
+    comment: "computed with speclite – see scripts/check_zeropoints.py"
   psf_fwhm:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/pdf/2108.13045.pdf"
+    comment: "See \"Wide\" in table 1"
   effective_wavelength:
-    link: ""
-    comment: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html#hsc-filters"
+    comment: "computed with speclite – see scripts/check_effective_wavelength.py"
+
+# Notes
+# -----
+# The reference link for sky_brightness for Suprime-Cam, should be approximately okay.
+# Here is the updated version for HSC as of July 2021
+# https://www.subarutelescope.org/Observing/Instruments/HSC/hsc_etc_report.html.
+# We could update the numbers to this version, although we need to
+# convert the unit from ADU/sec to mag/arcsec^2.

--- a/galcheat/data/LSST.yaml
+++ b/galcheat/data/LSST.yaml
@@ -1,32 +1,3 @@
-# gain
-# https://github.com/LSSTDESC/imSim/blob/main/imsim/stamp.py#L416
-#
-# mirror_diameter
-# https://www.lsst.org/about/tel-site/optical_design
-#
-# obscuration
-# the current value is computed from the effective area found in WLD
-# https://github.com/LSSTDESC/WeakLensingDeblending/blob/master/descwl/survey.py#L192
-# 1-32.4/(pi*8.36*8.36/4)
-# you can also find information at
-# https://github.com/aboucaud/galcheat/issues/38
-#
-# zeropoint_airmass
-# https://speclite.readthedocs.io/en/latest/filters.html#lsst-filters
-#
-# https://www.lsst.org/about/camera/features
-#
-# zeropoint
-# computed with speclite: for more information you may want to check
-# https://github.com/aboucaud/galcheat/issues/48 and the zeropoints.py script
-#
-# psf_fwhm
-#
-#
-# effective_wavelength
-# computed with speclite: for more information you may want to check
-# https://github.com/aboucaud/galcheat/issues/36 and the effective_wavelengths.py script
-
 name: "LSST"
 description: "Legacy Survey of Space and Time (LSST) done with the Simonyi survey telescope and the LSST camera"
 pixel_scale: 0.2
@@ -79,32 +50,32 @@ filters:
     effective_wavelength: 972.202
 references:
   pixel_scale:
-    link: ""
-    comment: ""
+    link: "https://www.lsst.org/about/camera/features"
+    comment: "See Technical details"
   gain:
-    link: ""
+    link: "https://github.com/LSSTDESC/imSim/blob/main/imsim/stamp.py#L416"
     comment: ""
   mirror_diameter:
-    link: ""
+    link: "https://www.lsst.org/about/tel-site/optical_design"
     comment: ""
   obscuration:
-    link: ""
-    comment: ""
+    link: "https://arxiv.org/abs/0805.2366"
+    comment: "See https://github.com/aboucaud/galcheat/issues/38 for discussions"
   zeropoint_airmass:
-    link: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html#lsst-filters"
     comment: ""
   sky_brightness:
-    link: ""
+    link: "https://www.lsst.org/about/camera/features"
     comment: ""
   exposure_time:
-    link: ""
-    comment: ""
+    link: "https://www.lsst.org/about/camera/features"
+    comment: "See Technical details"
   zeropoint:
-    link: ""
-    comment: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html#lsst-filters"
+    comment: "computed with speclite – see scripts/check_zeropoints.py"
   psf_fwhm:
     link: ""
     comment: ""
   effective_wavelength:
-    link: ""
-    comment: ""
+    link: "https://speclite.readthedocs.io/en/latest/filters.html#lsst-filters"
+    comment: "computed with speclite – see scripts/check_effective_wavelength.py"

--- a/galcheat/data/LSST.yaml
+++ b/galcheat/data/LSST.yaml
@@ -77,3 +77,34 @@ filters:
     zeropoint: 26.56
     psf_fwhm: 0.703
     effective_wavelength: 972.202
+references:
+  pixel_scale:
+    link: ""
+    comment: ""
+  gain:
+    link: ""
+    comment: ""
+  mirror_diameter:
+    link: ""
+    comment: ""
+  obscuration:
+    link: ""
+    comment: ""
+  zeropoint_airmass:
+    link: ""
+    comment: ""
+  sky_brightness:
+    link: ""
+    comment: ""
+  exposure_time:
+    link: ""
+    comment: ""
+  zeropoint:
+    link: ""
+    comment: ""
+  psf_fwhm:
+    link: ""
+    comment: ""
+  effective_wavelength:
+    link: ""
+    comment: ""

--- a/galcheat/data/README.md
+++ b/galcheat/data/README.md
@@ -3,8 +3,11 @@
 
 The following document describes the parameters expected for the photometric surveys and their filters: how they should be computed, their units, etc.
 
+[**Survey parameters**](#survey-parameters) | [**Filter parameters**](#filter-parameters) | [**References**](#references) | [**Data file layout**](#yaml-file-layout)
+
 Survey parameters
 -----------------
+
 ### Units and types
 
 | parameter name    | type  | units          |
@@ -94,6 +97,13 @@ Average full width at half-maximum (FWHM) of the point spread function (PSF) ove
 Wavelength computed as a weighted average of the full passband throughput over the wavelength range.  
 The throughput takes into account the transmission of the filter, the transmittance of the optics, the CCD efficiency as well as a standard atmospheric extinction model.
 
+References
+----------
+
+The parameters written in `galcheat` have all been sourced and referenced.
+
+These references can be specified for each parameter as a link and a comment string.
+
 YAML file layout
 ----------------
 
@@ -129,4 +139,15 @@ filters:
     zeropoint: 27.36
     psf_fwhm: 1.2
     effective_wavelength: 600.00
+references:
+  pixel_scale:
+    link: "https://link-to-the-pixelscale-ref.com"
+    comment: "See section 2.4"
+  gain:
+    link: "https://link-to-the-gain-info.org"
+    comment: ""
+  psf_fwhm:
+    link: "https://link-to-filters-refs.org"
+    comment: ""
+# goal is to have a reference per parameter, survey or filter-wise...
 ```

--- a/galcheat/helpers.py
+++ b/galcheat/helpers.py
@@ -16,7 +16,7 @@ def get_survey(survey_name: str) -> Survey:
 
     Parameters
     ----------
-    survey_name: str
+    survey_name : str
         Name of a survey among the `available_surveys`
 
     Returns
@@ -42,9 +42,9 @@ def get_filter(filter_name: str, survey_name: str) -> Filter:
 
     Parameters
     ----------
-    filter_name: str
+    filter_name : str
         Name of a filter belonging to `survey_name`
-    survey_name: str
+    survey_name : str
         Name of a survey among the `available_surveys`
 
     Returns
@@ -61,12 +61,15 @@ def get_filter(filter_name: str, survey_name: str) -> Filter:
     return survey.get_filter(filter_name)
 
 
-def print_survey(survey):
+def print_survey(survey, show_refs=False):
     """Print information on a given survey
 
     Parameters
     ----------
-    survey: str or Survey instance
+    survey : str or Survey
+        The survey name or Survey instance
+    show_refs : bool
+        Print the references for each parameter.
 
     """
     if not isinstance(survey, Survey):
@@ -75,3 +78,31 @@ def print_survey(survey):
     print(survey)
     for filter_name in survey.available_filters:
         print(survey.get_filter(filter_name))
+    if show_refs:
+        print_references(survey.references)
+
+
+def print_references(references):
+    """Pretty print the references of the survey and filter parameters
+
+    The references are composed of a link and a sentence for comments.
+
+    Parameters
+    ----------
+    references : dict
+        Dictionary with the references for each parameter
+
+    """
+    name_size = max(len(name) for name in references)
+    link_size = max(len(param["link"]) for param in references.values())
+    comment_size = max(len(param["comment"]) for param in references.values())
+    header = f"{'Parameter name':<{name_size}} | {'Reference link':<{link_size}} | {'Comments':<{comment_size}}"
+
+    print("\n-=[ References ]=-\n")
+    print(header)
+    print("-" * len(header))
+    for name, param in references.items():
+        print(
+            f"{name:<{name_size}} | {param['link']:<{link_size}} | {param['comment']:<{comment_size}}"
+        )
+    print("-" * len(header))

--- a/galcheat/survey.py
+++ b/galcheat/survey.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass, field, make_dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import astropy.units as u
 import yaml
@@ -21,7 +21,7 @@ class Survey:
     zeropoint_airmass: Quantity
     available_filters: List[str] = field(init=False)
     effective_area: Quantity = field(init=False)
-    references: Optional[Dict[str, Dict[str, str]]]
+    references: Dict[str, Dict[str, str]]
 
     @classmethod
     def from_yaml(cls, yaml_file):
@@ -56,7 +56,7 @@ class Survey:
             gain,
             obscuration,
             zeropoint_airmass,
-            data.get("references"),
+            data["references"],
         )
 
     def __repr__(self):

--- a/galcheat/survey.py
+++ b/galcheat/survey.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass, field, make_dataclass
-from typing import Any, List
+from typing import Any, Dict, List, Optional
 
 import astropy.units as u
 import yaml
@@ -21,6 +21,7 @@ class Survey:
     zeropoint_airmass: Quantity
     available_filters: List[str] = field(init=False)
     effective_area: Quantity = field(init=False)
+    references: Optional[Dict[str, Dict[str, str]]]
 
     @classmethod
     def from_yaml(cls, yaml_file):
@@ -55,6 +56,7 @@ class Survey:
             gain,
             obscuration,
             zeropoint_airmass,
+            data.get("references"),
         )
 
     def __repr__(self):
@@ -66,7 +68,7 @@ class Survey:
         printed_params = [
             f"  {key:<20} = {val}"
             for key, val in self.__dict__.items()
-            if key not in ("name", "description", "filters")
+            if key not in ("name", "description", "filters", "references")
         ]
         survey_repr += "\n".join(printed_params)
         return survey_repr


### PR DESCRIPTION
This PR aims at providing references as part of the command line interface, in a readable format.

Try it out using 

```sh
galcheat --refs
```