### PR TITLE
Remove generic get_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,16 @@ API
 # The list of available surveys
 from galcheat import available_surveys
 
-# Getter methods to retrieve a Survey of a Filter dataclass
-from galcheat import get_survey, get_filter
+# Getter method to retrieve a Survey dataclass
+from galcheat import get_survey
 
 LSST = get_survey("LSST")
-u_band = get_filter("u", "LSST")
-# which is a proxy for
-u_band = LSST.get_filter("u")
 
-# Get the list of available filters
+# Get the list of available filter names
 LSST.available_filters
 
-# or as a dictionary with all `Filter` objects
-LSST.get_filters()
+# and then pick a Filter dataclass
+u_band = LSST.get_filter("u")
 
 # Both Survey and Filter classes have physical attributes
 LSST.mirror_diameter

--- a/galcheat/__init__.py
+++ b/galcheat/__init__.py
@@ -59,4 +59,4 @@ parameter values for your surveys of
 interest or reporting inconsistent values.
 
 """
-from galcheat.helpers import available_surveys, get_filter, get_survey  # noqa
+from galcheat.helpers import available_surveys, get_survey  # noqa

--- a/galcheat/helpers.py
+++ b/galcheat/helpers.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from galcheat.filter import Filter
 from galcheat.survey import Survey
 
 _BASEDIR = Path(__file__).parent.resolve()
@@ -35,27 +34,3 @@ def get_survey(survey_name: str) -> Survey:
         )
 
     return _survey_info[survey_name]
-
-
-def get_filter(filter_name: str, survey_name: str) -> Filter:
-    """Get the filter class from the corresponding survey
-
-    Parameters
-    ----------
-    filter_name: str
-        Name of a filter belonging to `survey_name`
-    survey_name: str
-        Name of a survey among the `available_surveys`
-
-    Returns
-    -------
-    a Filter dataclass
-
-    Raises
-    ------
-    ValueError: when the survey or filter is not available
-
-    """
-    survey = get_survey(survey_name)
-
-    return survey.get_filter(filter_name)


### PR DESCRIPTION
The global `get_filter` method adds a second way of retrieving a filter object.
The prefered way should be `survey.get_filter('filtername')` and to simplify the API, I guess we should remove the global one and only leave a single getter for it.