### PR TITLE
Distinguish between str and repr for dataclasses

### DIFF
--- a/galcheat/filter.py
+++ b/galcheat/filter.py
@@ -48,7 +48,7 @@ class Filter:
             wavelength,
         )
 
-    def __repr__(self):
+    def __str__(self):
         filter_repr = f"-= {self.name} filter =-\n"
         printed_params = [
             f"  {key:<20} = {val}"
@@ -57,3 +57,6 @@ class Filter:
         ]
         filter_repr += "\n".join(printed_params)
         return filter_repr
+
+    def __repr__(self):
+        return f"Filter {self.name}"

--- a/galcheat/survey.py
+++ b/galcheat/survey.py
@@ -59,7 +59,7 @@ class Survey:
             data["references"],
         )
 
-    def __repr__(self):
+    def __str__(self):
         n = len(self.name)
         survey_repr = "-" * (n + 4) + "\n"
         survey_repr += f"| {self.name} |"
@@ -72,6 +72,9 @@ class Survey:
         ]
         survey_repr += "\n".join(printed_params)
         return survey_repr
+
+    def __repr__(self):
+        return f"Survey {self.name}"
 
     @staticmethod
     def _construct_filter_list(survey_dict):


### PR DESCRIPTION
The string representation `__str__` is used for printing the class but the representation used internally to display the class in dictionaries or in the REPL use the `__repr__` method et do not need to display all parameters.