### PR TITLE
Update hooks especially black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.2.0
   hooks:
     - id: check-merge-conflict
     - id: check-yaml
@@ -17,7 +17,7 @@ repos:
     - id: isort
       args: [--profile, black]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.31.0
+  rev: v2.31.1
   hooks:
     - id: pyupgrade
       args: [--py37-plus]
@@ -28,6 +28,6 @@ repos:
      additional_dependencies: [flake8-typing-imports==1.7.0]
      args: ['--ignore=E501,E203,E731,W503']
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
     - id: black


### PR DESCRIPTION
There was an incompatibility between black and click versions. 

This has been fixed in a patch. This PR updates the black version.