### PR TITLE
Significant digits

### DIFF
--- a/galcheat/data/CFHTLS.yaml
+++ b/galcheat/data/CFHTLS.yaml
@@ -3,7 +3,7 @@ description: "Canada France Hawaii Lensing wide-field Survey (CFHTLS) done with 
 pixel_scale: 0.187
 gain: 1.67
 mirror_diameter: 3.58
-obscuration: 0.20309772
+obscuration: 0.20
 zeropoint_airmass: 1.0
 filters:
   u:

--- a/galcheat/data/DES.yaml
+++ b/galcheat/data/DES.yaml
@@ -3,7 +3,7 @@ description: "Dark Energy wide-field Survey (DES) done with the Victor M. Blanco
 pixel_scale: 0.2637
 gain: 4.0
 mirror_diameter: 3.934
-obscuration: 0.17612680
+obscuration: 0.18
 zeropoint_airmass: 1.3
 filters:
   g:

--- a/galcheat/data/HSC.yaml
+++ b/galcheat/data/HSC.yaml
@@ -3,7 +3,7 @@ description: "Hyper Suprime-Cam (HSC) wide-field survey done with the Subaru tel
 pixel_scale: 0.168
 gain: 3.0
 mirror_diameter: 8.3
-obscuration: 0.02090289
+obscuration: 0.02
 zeropoint_airmass: 1.2
 filters:
   g:

--- a/galcheat/data/LSST.yaml
+++ b/galcheat/data/LSST.yaml
@@ -3,7 +3,7 @@ description: "Legacy Survey of Space and Time (LSST) done with the Simonyi surve
 pixel_scale: 0.2
 gain: 1.0
 mirror_diameter: 8.36
-obscuration: 0.39257227
+obscuration: 0.39
 zeropoint_airmass: 1.2
 filters:
   u:


### PR DESCRIPTION
I open this PR regarding the number of significant digits to use for each parameter #107.

I just started with the `obscuration` that had too many digits that I reduced to 2. For numbers that we compute like this, it should be easy to set a common precision for all surveys.
The other parameter that looks weird at first glance is `effective_wavelength` that has 3 digits, which we could set to 2 digits as well ?

Then I noticed that e.g., `sky_brightness` has 2 digits in `LSST` but 1 in `HSC`. So I wonder if we should keep the precision from the values given in references or if we should set a precision for each parameter and get it consistent across surveys.

