### PR TITLE
Update Euclid VIS filter name

### DIFF
--- a/galcheat/data/Euclid_VIS.yaml
+++ b/galcheat/data/Euclid_VIS.yaml
@@ -6,8 +6,8 @@ mirror_diameter: 1.2
 obscuration: 0.13
 zeropoint_airmass: 0.0
 filters:
-  VIS:
-    name: "VIS"
+  IE:
+    name: "IE"
     sky_brightness: 22.3203
     full_exposure_time: 565
     zeropoint: 25.91

--- a/scripts/check_effective_wavelengths.py
+++ b/scripts/check_effective_wavelengths.py
@@ -29,6 +29,8 @@ def check_effective_wavelengths(survey_name):
         print("------- | --------- | ---------")
 
         for filter_name in survey.available_filters:
+            if filter_name == "IE":
+                filter_name = "VIS"
             speclite_filter_name = f"{speclite_prefix}-{filter_name}"
             speclite_filter = load_filter(speclite_filter_name)
             speclite_eff_wl = speclite_filter.effective_wavelength.to(u.nm)

--- a/scripts/check_effective_wavelengths.py
+++ b/scripts/check_effective_wavelengths.py
@@ -30,8 +30,10 @@ def check_effective_wavelengths(survey_name):
 
         for filter_name in survey.available_filters:
             if filter_name == "IE":
-                filter_name = "VIS"
-            speclite_filter_name = f"{speclite_prefix}-{filter_name}"
+                old_filter_name = "VIS"
+            else:
+                old_filter_name = filter_name
+            speclite_filter_name = f"{speclite_prefix}-{old_filter_name}"
             speclite_filter = load_filter(speclite_filter_name)
             speclite_eff_wl = speclite_filter.effective_wavelength.to(u.nm)
             current_eff_wl = survey.get_filter(filter_name).effective_wavelength

--- a/scripts/check_zeropoints.py
+++ b/scripts/check_zeropoints.py
@@ -41,6 +41,8 @@ def check_zeropoints(survey_name):
         print("------- | --------- | ---------")
 
         for filter_name in survey.available_filters:
+            if filter_name == "IE":
+                filter_name = "VIS"
             speclite_filter_name = f"{speclite_prefix}-{filter_name}"
             zp_24 = (
                 calculate_zero_point(speclite_filter_name)

--- a/scripts/check_zeropoints.py
+++ b/scripts/check_zeropoints.py
@@ -42,8 +42,10 @@ def check_zeropoints(survey_name):
 
         for filter_name in survey.available_filters:
             if filter_name == "IE":
-                filter_name = "VIS"
-            speclite_filter_name = f"{speclite_prefix}-{filter_name}"
+                old_filter_name = "VIS"
+            else:
+                old_filter_name = filter_name
+            speclite_filter_name = f"{speclite_prefix}-{old_filter_name}"
             zp_24 = (
                 calculate_zero_point(speclite_filter_name)
                 * survey.effective_area


### PR DESCRIPTION
The new Euclid convention is to name the Euclid filters using their name in capital followed by a E to refer to Euclid